### PR TITLE
Use --comments to avoid stripping comments sent to tidb-server

### DIFF
--- a/src/get-started/build-tidb-from-source.md
+++ b/src/get-started/build-tidb-from-source.md
@@ -53,7 +53,14 @@ This starts the TiDB server listening on port 4000 with embedded `unistore`.
 You can use official MySQL client to connect to TiDB:
 
 ```bash
-mysql -h 127.0.0.1 -P 4000 -u root -D test --prompt="tidb> "
+mysql -h 127.0.0.1 -P 4000 -u root -D test --prompt="tidb> " --comments
 ```
+Where:
+- `-h 127.0.0.1` sets the Host to local host loopback interface
+- `-P 4000` uses port 4000
+- `-u root` connect as root user (`-p` not given, the development build has no password for root)
+- `-D test` use Schema/Database test
+- `--prompt "tidb> "` sets the prompt to distinguish it from a connection to MySQL
+- `--comments` preserves comments like `/*T![clustered_index NONCLUSTERED */` instead of stripping them when sending the query to the server.
 
 If you encounter any problems during your journey, do not hesitate to reach out on the [TiDB Internals forum](https://internals.tidb.io/).


### PR DESCRIPTION
Example where it would be confusing:
mysql --host 127.0.0.1 --port 4000 -u root --prompt='tidb> ' -D test
...
tidb> CREATE TABLE `t` (
    ->   `id` int(10) unsigned NOT NULL,
    ->   `v` varchar(255) DEFAULT NULL,
    ->   PRIMARY KEY (`id`) /*T![clustered_index] NONCLUSTERED */
    -> ) ;
Query OK, 0 rows affected (0,01 sec)

tidb> show create table t\G
*************************** 1. row ***************************
       Table: t
Create Table: CREATE TABLE `t` (
  `id` int(10) unsigned NOT NULL,
  `v` varchar(255) DEFAULT NULL,
  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
1 row in set (0,00 sec)

Notice that I copied a CREATE TABLE statement with a NONCLUSTERED index,
but due to --comments was not given, it created a CLUSTERED index!

<!-- Thank you for contributing to TiDB Development Guide!  -->
<!-- Please follow the PR title format:                     -->
<!--    "section: what's changed"                           -->

### What issue does this PR solve?

Be more clear about the options for the mysql client, and using `--comments` to avoid confusing situations where the TiDB specific comments are stripped from the query sent to the server.

### What is changed:
