### PR TITLE
TiDB could compile and run on Windows, therefore 'should' is a wrong word

### DIFF
--- a/src/get-started/build-tidb-from-source.md
+++ b/src/get-started/build-tidb-from-source.md
@@ -8,7 +8,7 @@
 
 > **Note:**
 >
-> TiDB should compile and run on Windows 10. However, it is not expected to be deployed on Windows, where you might encounter many compatibility problems. To have a better experience, we recommend you [install WSL2](https://docs.microsoft.com/en-us/windows/wsl/install-win10) first.
+> TiDB could compile and run on Windows 10. However, it is not expected to be deployed on Windows, where you might encounter many compatibility problems. To have a better experience, we recommend you [install WSL2](https://docs.microsoft.com/en-us/windows/wsl/install-win10) first.
 
 ## Clone
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB Development Guide!  -->
<!-- Please follow the PR title format:                     -->
<!--    "section: what's changed"                           -->

### What is changed:
"TiDB should compile and run on Windows 10. However, it is not expected to be deployed on Windows, where you might encounter many compatibility problems. To have a better experience, we recommend you install WSL2 first."

This description leads to a misunderstanding that TiDB can be only compiled on Windows which is obvious wrong. 