### PR TITLE
change committer guide order

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -12,7 +12,6 @@
 
 * [Contribute to TiDB](contribute-to-tidb/introduction.md)
     * [Community Guideline](contribute-to-tidb/community-guideline.md)
-    * [Committer Guide](contribute-to-tidb/committer-guide.md)
     * [Report an Issue](contribute-to-tidb/report-an-issue.md)
     * [Issue Triage](contribute-to-tidb/issue-triage.md)
     * [Contribute Code](contribute-to-tidb/contribute-code.md)
@@ -21,6 +20,7 @@
     * [Make a Proposal](contribute-to-tidb/make-a-proposal.md)
     * [Code Style and Quality Guide](contribute-to-tidb/code-style-and-quality-guide.md)
     * [Write Document](contribute-to-tidb/write-document.md)
+    * [Committer Guide](contribute-to-tidb/committer-guide.md)
     * [Miscellaneous Topics](contribute-to-tidb/miscellaneous-topics.md)
 
 * [Understand TiDB](understand-tidb/introduction.md)

--- a/src/contribute-to-tidb/introduction.md
+++ b/src/contribute-to-tidb/introduction.md
@@ -14,7 +14,6 @@ TiDB is developed by an open and friendly community. Everybody is cordially welc
 Here are guidelines for contributing to various aspect of the project:
 
 * [Community Guideline](community-guideline.md)
-* [Committer Guide](committer-guide.md)
 * [Report an Issue](report-an-issue.md)
 * [Issue Triage](issue-triage.md)
 * [Contribute Code](contribute-code.md)
@@ -23,6 +22,7 @@ Here are guidelines for contributing to various aspect of the project:
 * [Make a Proposal](make-a-proposal.md)
 * [Code Style and Quality Guide](code-style-and-quality-guide.md)
 * [Write Document](write-document.md)
+* [Committer Guide](committer-guide.md)
 * [Miscellaneous Topics](miscellaneous-topics.md)
 
 Any other question? Reach out to the [TiDB Internals forum](https://internals.tidb.io/) to get help!


### PR DESCRIPTION
### What is changed:

I'd like to put commiter guide chapter at the back since most readers are not committer, put it at front seems not natural.