### PR TITLE
docs: Bump go version from 1.16 to 1.18

### DIFF
--- a/src/get-started/install-golang.md
+++ b/src/get-started/install-golang.md
@@ -2,9 +2,9 @@
 
 To build TiDB from source code, you need to install Go in your development environment first. If Go is not installed yet, you can follow the instructions in this document for installation.
 
-## Install Go 1.16
+## Install Go 1.18
 
-Currently, TiDB uses Go 1.16 to compile the code. To install Go 1.16, go to [Go's download page](https://golang.org/dl/), choose version 1.16, and then follow the [installation instructions](https://golang.org/doc/install).
+Currently, TiDB uses Go 1.18 to compile the code. To install Go 1.18, go to [Go's download page](https://golang.org/dl/), choose version 1.18, and then follow the [installation instructions](https://golang.org/doc/install).
 
 ## Manage the Go toolchain using gvm
 
@@ -16,11 +16,11 @@ To install gvm, run the following command:
 curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer | sh
 ```
 
-Once you have gvm installed, you can use it to manage multiple different Go compilers with different versions. Let's install Go 1.16 and set it as default:
+Once you have gvm installed, you can use it to manage multiple different Go compilers with different versions. Let's install Go 1.18 and set it as default:
 
 ```bash
-gvm install go1.16
-gvm use go1.16 --default
+gvm install go1.18
+gvm use go1.18 --default
 ```
 
 Now, you can type `go version` in the shell to verify the installation:
@@ -28,7 +28,7 @@ Now, you can type `go version` in the shell to verify the installation:
 ```bash
 go version
 # OUTPUT:
-# go version go1.16 linux/amd64
+# go version go1.18 linux/amd64
 ```
 
 In the next chapter, you will learn how to obtain the TiDB source code and how to build it.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB Development Guide!  -->
<!-- Please follow the PR title format:                     -->
<!--    "section: what's changed"                           -->

### What issue does this PR solve?

<!-- only need to keep one of the following lines -->

- close #xxxx
- to #xxxx

### What is changed:
This pull request bumps go version from 1.16 to 1.18 in the getting started page to follow up https://github.com/pingcap/tidb/issues/32874