### PR TITLE
understand-tidb: fix mysql dev page link

### DIFF
--- a/src/understand-tidb/dql.md
+++ b/src/understand-tidb/dql.md
@@ -33,7 +33,7 @@ data, err := cc.readPacket()
 if err = cc.dispatch(ctx, data)
 ```
 
-`dispatch` handles the raw data array. The first byte of the array represents command type. Among the types, `COM_QUERY` represents data query statement. You can refer to [MySQL protocol](https://dev.mysql.com/doc/internals/en/client-server-protocol.html) for more information about the data array. For `COM_QUERY`, its content is SQL statement. [clientConn.handleQuery()](https://github.com/pingcap/tidb/blob/05d2210647d6a1503a8d772477e43b14a024f609/server/conn.go#L1633) handles the SQL statement. It calls [TiDBContext.ExecuteStmt()](https://github.com/pingcap/tidb/blob/05d2210647d6a1503a8d772477e43b14a024f609/server/driver_tidb.go#L217) in `server/driver_tidb.go`:
+`dispatch` handles the raw data array. The first byte of the array represents command type. Among the types, `COM_QUERY` represents data query statement. You can refer to [MySQL protocol](https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_PROTOCOL.html) for more information about the data array. For `COM_QUERY`, its content is SQL statement. [clientConn.handleQuery()](https://github.com/pingcap/tidb/blob/05d2210647d6a1503a8d772477e43b14a024f609/server/conn.go#L1633) handles the SQL statement. It calls [TiDBContext.ExecuteStmt()](https://github.com/pingcap/tidb/blob/05d2210647d6a1503a8d772477e43b14a024f609/server/driver_tidb.go#L217) in `server/driver_tidb.go`:
 
 ```go
 func (tc *TiDBContext) ExecuteStmt(ctx context.Context, stmt ast.StmtNode) (ResultSet, error) {
@@ -44,7 +44,7 @@ func (tc *TiDBContext) ExecuteStmt(ctx context.Context, stmt ast.StmtNode) (Resu
 
 #### Exit
 
-After a series of operations described above, the execution results will be returned to the client in [COM_QUERY response](https://dev.mysql.com/doc/internals/en/com-query-response.html) format by [clientConn.writeResultSet()](https://github.com/pingcap/tidb/blob/05d2210647d6a1503a8d772477e43b14a024f609/server/conn.go#L1943).
+After a series of operations described above, the execution results will be returned to the client in [COM_QUERY response](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query_response.html) format by [clientConn.writeResultSet()](https://github.com/pingcap/tidb/blob/05d2210647d6a1503a8d772477e43b14a024f609/server/conn.go#L1943).
 
 ### SQL Layer
 

--- a/src/understand-tidb/introduction.md
+++ b/src/understand-tidb/introduction.md
@@ -89,7 +89,7 @@ This is a detailed SQL layer architecture graph. You can read it from left to ri
 
 The leftmost is the Protocol Layer of TiDB, this is the interface to interact with Client, currently TiDB only supports MySQL protocol, the related code is in the `server` package.
 
-The purpose of this layer is to manage the client connection, parse MySQL commands and return the execution result. The specific implementation is according to MySQL protocol, you can refer to [MySQL Client/Server Protocol document](https://dev.mysql.com/doc/internals/en/client-server-protocol.html). If you need to use MySQL protocol parsing and processing functions in your project, you can refer to this module.
+The purpose of this layer is to manage the client connection, parse MySQL commands and return the execution result. The specific implementation is according to MySQL protocol, you can refer to [MySQL Client/Server Protocol document](https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_PROTOCOL.html). If you need to use MySQL protocol parsing and processing functions in your project, you can refer to this module.
 
 The logic for connection establishment is in the `Run()` method of `server.go`, mainly in the following two lines.
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB Development Guide!  -->
<!-- Please follow the PR title format:                     -->
<!--    "section: what's changed"                           -->

### What issue does this PR solve?

<!-- only need to keep one of the following lines -->

No github issue.

### What is changed:
When you access to `https://dev.mysql.com/doc/internals/...` which is used in this dev-guide, you are redirected to https://dev.mysql.com/doc/dev/mysql-server/latest/ and can't see what this guide want to show.

I found new page for each link and updated the links.

