### PR TITLE
docs: update paths for yy_parser.go and lexer.go

### DIFF
--- a/src/understand-tidb/dql.md
+++ b/src/understand-tidb/dql.md
@@ -61,7 +61,7 @@ The most important function in `Session` is `ExecuteStmt`. It wraps calls to oth
 
 #### [Parser](parser.md)
 
-[Parser](https://github.com/pingcap/tidb/blob/master/parser/yy_parser.go) consists of [Lexer](https://github.com/pingcap/tidb/blob/master/parser/lexer.go) and Yacc. It turns the SQL text to AST:
+[Parser](https://github.com/pingcap/tidb/blob/master/pkg/parser/yy_parser.go) consists of [Lexer](https://github.com/pingcap/tidb/blob/master/pkg/parser/lexer.go) and Yacc. It turns the SQL text to AST:
 
 ```go
 p := parserPool.Get().(*parser.Parser)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB Development Guide!  -->
<!-- Please follow the PR title format:                     -->
<!--    "section: what's changed"                           -->

### What issue does this PR solve?

<!-- only need to keep one of the following lines -->

clicking yy_parser.go and lexer.go links in "Understand TiDB" section, shows 404

<img width="1645" alt="スクリーンショット 2024-04-13 15 38 14" src="https://github.com/pingcap/tidb-dev-guide/assets/142221789/c0b9818c-b6a7-4b1d-a29e-5dd2cb25068b">


### What is changed:

update paths for yy_parser.go and lexer.go in "Understand TiDB" section