### PR TITLE
Fix typo: "asyncronous" to "asynchronous"

### DIFF
--- a/src/understand-tidb/ddl.md
+++ b/src/understand-tidb/ddl.md
@@ -25,7 +25,7 @@ The states used are defined in [tidb/parser/model/model.go](https://github.com/p
         StatePublic
 ```
 
-Note: this is a very different implementation from MySQL, which uses Meta Data Locks (MDL) for keeping a single version of the MySQL instance schemas at a time. This results in MySQL replicas can have different version of the schemas, due to lag in asyncronous replication. TiDB has always a consistent view of all schemas in the cluster.
+Note: this is a very different implementation from MySQL, which uses Meta Data Locks (MDL) for keeping a single version of the MySQL instance schemas at a time. This results in MySQL replicas can have different version of the schemas, due to lag in asynchronous replication. TiDB has always a consistent view of all schemas in the cluster.
 
 ## Implementation
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB Development Guide!  -->
<!-- Please follow the PR title format:                     -->
<!--    "section: what's changed"                           -->

### What issue does this PR solve?

<!-- only need to keep one of the following lines -->

- close #xxxx
- to #xxxx

### What is changed:

This PR fixes a typo where "asynchronous" was incorrectly spelled as "asyncronous" (missing the 'h').