### PR TITLE
Install Golang: Fix regex for retrieving Go version info (support x.x and x.x.x)

### DIFF
--- a/src/get-started/install-golang.md
+++ b/src/get-started/install-golang.md
@@ -9,7 +9,7 @@ TiDB periodically upgrades its Go version to keep up with Golang. Currently, upg
 To get the right version of Go, take a look at the [`go.mod` file in TiDB's repository](https://github.com/pingcap/tidb/blob/master/go.mod). You should see that there is a line like `go 1.21` (the number may be different) in the first few lines of this file. You can also run the following command to get the Go version:
 
 ```bash
-curl -s -S -L https://github.com/pingcap/tidb/blob/master/go.mod | grep -Eo "\"go [[:digit:]]+.[[:digit:]]+\""
+curl -s -S -L https://github.com/pingcap/tidb/blob/master/go.mod | grep -Eo "\"go [[:digit:]]+(\.[[:digit:]]+)+\""
 ```
 
 Now that you've got the version number, go to [Go's download page](https://golang.org/dl/), choose the corresponding version, and then follow the [installation instructions](https://golang.org/doc/install).
@@ -27,7 +27,7 @@ curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gv
 Once you have gvm installed, you can use it to manage multiple different Go compilers with different versions. Let's install the corresponding Go version and set it as default:
 
 ```bash
-TIDB_GOVERSION=$(curl -s -S -L https://github.com/pingcap/tidb/blob/master/go.mod | grep -Eo "\"go [[:digit:]]+.[[:digit:]]+\"" | grep -Eo "[[:digit:]]+.[[:digit:]]+")
+TIDB_GOVERSION=$(curl -s -S -L https://github.com/pingcap/tidb/blob/master/go.mod | grep -Eo "\"go [[:digit:]]+(\.[[:digit:]]+)+\"" | grep -Eo "[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+)?")
 gvm install go${TIDB_GOVERSION}
 gvm use go${TIDB_GOVERSION} --default
 ```


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB Development Guide!  -->
<!-- Please follow the PR title format:                     -->
<!--    "section: what's changed"                           -->

### What issue does this PR solve?

When following the guide to obtain the Go version, the version could not be retrieved correctly. Further investigation revealed that the problem lies in the regular expression, which fails to extract version numbers formatted as x.x.x.

![Screenshot from 2025-04-07 21-02-28](https://github.com/user-attachments/assets/397d14e5-96b8-4e65-bc1f-deaed29d77e7)

### What is changed:

- **Regex Update in `install-golang.md`:**  
  The regular expression in the installation instructions has been extended to support both two-segment (e.g., `go 1.19`) and three-segment (e.g., `go 1.19.5`) version formats. This ensures that the correct Go version is extracted from the `go.mod` file regardless of its format.

### Verification Steps:
1. **Extract Go Version from go.mod:**  
   Run the following command to verify that the updated regex correctly extracts the version string from the `go.mod` file:

```bash
curl -s -S -L https://github.com/pingcap/tidb/blob/master/go.mod | grep -Eo "\"go [[:digit:]]+(\.[[:digit:]]+)+\""
```

![Screenshot from 2025-04-07 21-04-04](https://github.com/user-attachments/assets/a7080ab3-1e16-4332-a620-56523cb0208e)


2. Test with Sample Inputs:
Validate the regex by testing it against both two-segment and three-segment version strings:

```bash
echo "\"go 1.23\"" | grep -Eo "\"go [[:digit:]]+(\.[[:digit:]]+)+\""
echo "\"go 1.23.8\"" | grep -Eo "\"go [[:digit:]]+(\.[[:digit:]]+)+\""
```
Both commands should output the version strings correctly.

![Screenshot from 2025-04-07 21-05-03](https://github.com/user-attachments/assets/54448815-be13-44ca-b2ba-8005b6861b0b)


3. Check Environment Variable Assignment:
Ensure that the command used to set the TIDB_GOVERSION variable works as expected:

```bash
TIDB_GOVERSION=$(curl -s -S -L https://github.com/pingcap/tidb/blob/master/go.mod | grep -Eo "\"go [[:digit:]]+(\.[[:digit:]]+)+\"" | grep -Eo "[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+)?")
echo $TIDB_GOVERSION
```

This should print the correct Go version string, confirming that the regex update is effective.

![Screenshot from 2025-04-07 21-05-55](https://github.com/user-attachments/assets/3f18127c-65d6-4863-9eea-ca2aab18cfe9)

Let me know if there are any further improvements or adjustments needed!

