### PR TITLE
add-a-function.md: update context parameters in function signatures

### DIFF
--- a/src/extending-tidb/add-a-function.md
+++ b/src/extending-tidb/add-a-function.md
@@ -45,7 +45,7 @@ type helloFunctionClass struct {
         baseFunctionClass
 }
 
-func (c *helloFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
+func (c *helloFunctionClass) getFunction(ctx BuildContext, args []Expression) (builtinFunc, error) {
         if err := c.verifyArgs(args); err != nil {
                 return nil, err
         }
@@ -67,8 +67,8 @@ func (b *builtinHelloSig) Clone() builtinFunc {
         return newSig
 }
 
-func (b *builtinHelloSig) evalString(row chunk.Row) (name string, isNull bool, err error) {
-        name, isNull, err = b.args[0].EvalString(b.ctx, row)
+func (b *builtinHelloSig) evalString(ctx EvalContext, row chunk.Row) (name string, isNull bool, err error) {
+        name, isNull, err = b.args[0].EvalString(ctx, row)
         if isNull || err != nil {
                 return name, isNull, err
         }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB Development Guide!  -->
<!-- Please follow the PR title format:                     -->
<!--    "section: what's changed"                           -->

### What issue does this PR solve?

While following the **“Add a function”** tutorial, I was unable to compile TiDB because the code snippets use outdated context types.  

The mismatch triggered the following build errors:

```
$ cd tidb
$ make
$ ./bin/tidb-server

CGO_ENABLED=1  GO111MODULE=on go build -tags codes  -ldflags '-X "github.com/pingcap/tidb/pkg/parser/mysql.TiDBReleaseVersion=5a5186162e-dirty" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBBuildTS=2025-04-13 03:53:25" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitHash=5a5186162ea6078400c5ed5e6bef9b7a46710bb7" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBGitBranch=master" -X "github.com/pingcap/tidb/pkg/util/versioninfo.TiDBEdition=Community" ' -o bin/tidb-server ./cmd/tidb-server
# github.com/pingcap/tidb/pkg/expression
pkg/expression/builtin_string.go:157:18: cannot use &builtinHelloSig{} (value of type *builtinHelloSig) as builtinFunc value in variable declaration: *builtinHelloSig does not implement builtinFunc (wrong type for method evalString)
                have evalString(chunk.Row) (string, bool, error)
                want evalString(EvalContext, chunk.Row) (string, bool, error)
pkg/expression/builtin_string.go:4426:46: undefined: sessionctx
pkg/expression/builtin_string.go:4435:16: cannot use sig (variable of type *builtinHelloSig) as builtinFunc value in return statement: *builtinHelloSig does not implement builtinFunc (wrong type for method evalString)
                have evalString(chunk.Row) (string, bool, error)
                want evalString(EvalContext, chunk.Row) (string, bool, error)
pkg/expression/builtin_string.go:4445:16: cannot use newSig (variable of type *builtinHelloSig) as builtinFunc value in return statement: *builtinHelloSig does not implement builtinFunc (wrong type for method evalString)
                have evalString(chunk.Row) (string, bool, error)
                want evalString(EvalContext, chunk.Row) (string, bool, error)
pkg/expression/builtin_string.go:4449:52: b.ctx undefined (type *builtinHelloSig has no field or method ctx)
make: *** [Makefile:207: server] Error 1
```

### What is changed:

- **helloFunctionClass#getFunction**:  
  Changed the context parameter type from `sessionctx.Context` to `BuildContext` to reflect the correct expected type.

- **builtinHelloSig#evalString**:  
  Updated the function signature by adding `EvalContext` as the first parameter. This change ensures that the implementation conforms to the expected interface signature.

### Function interface references:

For clarity, the expected function interfaces are defined as follows:

**functionClass interface in builtin.go**  
[View on GitHub](https://github.com/pingcap/tidb/blob/5a5186162ea6078400c5ed5e6bef9b7a46710bb7/pkg/expression/builtin.go#L617)
```go
type functionClass interface {
	// getFunction gets a function signature by the types and the counts of given arguments.
	getFunction(ctx BuildContext, args []Expression) (builtinFunc, error)
	// verifyArgsByCount verifies the count of parameters.
	verifyArgsByCount(l int) error
}
```

**builtinFunc interface in builtin.go**  
[View on GitHub](https://github.com/pingcap/tidb/blob/5a5186162ea6078400c5ed5e6bef9b7a46710bb7/pkg/expression/builtin.go#L542)
```go
type builtinFunc interface {
	...
	// evalString evaluates string representation of builtinFunc by given row.
	evalString(ctx EvalContext, row chunk.Row) (val string, isNull bool, err error)
	...
}
```

These interfaces indicate that the correct context types are `BuildContext` for `getFunction` and `EvalContext` for `evalString`. The original implementation used `sessionctx.Context` for `getFunction` and omitted the `EvalContext` parameter for `evalString`, which resulted in the compilation errors.

### Verification

I tested the updated code in my forked repository and confirmed that the TiDB server now compiles and runs correctly. The working commit can be reviewed here:  
[77ef28abcbbbf5db93be5b52191bddcbbff30bc2](https://github.com/YukihiroArakawa/tidb/commit/77ef28abcbbbf5db93be5b52191bddcbbff30bc2)

![Screenshot from 2025-04-13 17-26-13](https://github.com/user-attachments/assets/5cce199c-059c-4391-a365-091703c6da20)


These modifications correct the mismatches in the tutorial code, ensuring that the documentation accurately reflects the current implementation and enabling successful compilation and execution of the TiDB server.